### PR TITLE
gulpfile.jsとindex.ejsを修正

### DIFF
--- a/ufix/gulpfile.js
+++ b/ufix/gulpfile.js
@@ -24,7 +24,7 @@ var gulp = require( 'gulp' ),
 		srcDir : 'src/img',
 		dstDir : 'dist/img',
 		serverDir : 'localhost'
-	}
+	};
 
 /*
  * Sass

--- a/ufix/src/ejs/index.ejs
+++ b/ufix/src/ejs/index.ejs
@@ -1,5 +1,6 @@
 <% include common/_header %>
   <% include common/_headmenu %>
+    <body>
 
     <!-- start contents -->
     <div id="main">


### PR DESCRIPTION
gulpfileの変数の末尾に閉じセミコロンがなかったこと、
htmlにbodyタグがなかったことが原因。
